### PR TITLE
pkp/pkp-lib#6086 Adjust URL path for series index

### DIFF
--- a/pages/catalog/CatalogHandler.inc.php
+++ b/pages/catalog/CatalogHandler.inc.php
@@ -119,10 +119,18 @@ class CatalogHandler extends PKPCatalogHandler {
 	 * @return string
 	 */
 	function series($args, $request) {
-		$seriesPath = $args[0];
+		$seriesPath = isset($args[0]) ? $args[0] : null;
 		$page = isset($args[1]) ? (int) $args[1] : 1;
 		$templateMgr = TemplateManager::getManager($request);
 		$context = $request->getContext();
+
+		// Provide a list of series to browse
+		if (!$seriesPath) {
+			$seriesDao = DAORegistry::getDAO('SeriesDAO');
+			$allSeries = $seriesDao->getByPressId($context->getId())->toArray();
+			$templateMgr->assign('allSeries', $allSeries);
+			return $templateMgr->display('frontend/pages/catalogSeriesIndex.tpl');
+		}
 
 		// Get the series
 		$seriesDao = DAORegistry::getDAO('SeriesDAO'); /* @var $seriesDao SeriesDAO */
@@ -179,26 +187,6 @@ class CatalogHandler extends PKPCatalogHandler {
 
 		return $templateMgr->display('frontend/pages/catalogSeries.tpl');
 	}
-	
-	/** Show an index of the available series.
-	 * @param $args array
-	 * @param $request PKPRequest
-	 * @return string
-	 */
-
-	 function seriesIndex($args, $request) {
-		$templateMgr = TemplateManager::getManager($request);
-		$this->setupTemplate($request);
-		$press = $request->getPress();
-
-			// Provide a list of series to browse
-			$seriesDao = DAORegistry::getDAO('SeriesDAO');
-			$series = $seriesDao->getByPressId($press->getId());
-			$templateMgr->assign('browseSeriesFactory', $series);
-
-			// Display
-			$templateMgr->display('frontend/pages/catalogSeriesIndex.tpl');
-		}
 
 	/**
 	 * @deprecated Since OMP 3.2.1, use pages/search instead.

--- a/pages/catalog/index.php
+++ b/pages/catalog/index.php
@@ -23,7 +23,6 @@ switch ($op) {
 	case 'fullSize':
 	case 'newReleases':
 	case 'series':
-	case 'seriesIndex':
 	case 'thumbnail':
 	case 'results':
 		define('HANDLER_CLASS', 'CatalogHandler');

--- a/templates/frontend/pages/catalogSeriesIndex.tpl
+++ b/templates/frontend/pages/catalogSeriesIndex.tpl
@@ -5,12 +5,9 @@
  * Copyright (c) 2003-2017 John Willinsky
  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
  *
- * @brief Display the page to view books in a series in the catalog.
+ * @brief Display a list of series in the catalog.
  *
- * @uses $series Series Current series being viewed
- * @uses $publishedMonographs array List of published monographs in this series
- * @uses $featuredMonographIds array List of featured monograph IDs in this series
- * @uses $newReleasesMonographs array List of new monographs in this series
+ * @uses $allSeries Array List of series being viewed
  *}
 {include file="frontend/components/header.tpl" pageTitle="plugins.block.browse.series"}
 
@@ -28,34 +25,34 @@
 	<ul>
 
 		{* Series *}
-		{if $browseSeriesFactory && $browseSeriesFactory->getCount()}
+		{if !empty($allSeries)}
 
-		{iterate from=browseSeriesFactory item=browseSeriesItem}				
+		{foreach from=$allSeries item="series"}
 		<li>
-		
-		<div class="imageDescription">		
+
+		<div class="imageDescription">
 
 	{* Image and description *}
 
-			<div class="cover"> <a href="{url router=$smarty.const.ROUTE_PAGE page="catalog" op="series" path=$browseSeriesItem->getPath()|escape}">
-			<img src="{url router=$smarty.const.ROUTE_PAGE page="catalog" op="thumbnail" type="series" id=$browseSeriesItem->getId()|escape}" alt="{$browseSeriesItem->getLocalizedFullTitle()|escape}" /></a>
+			<div class="cover"> <a href="{url router=$smarty.const.ROUTE_PAGE page="catalog" op="series" path=$series->getPath()|escape}">
+			<img src="{url router=$smarty.const.ROUTE_PAGE page="catalog" op="thumbnail" type="series" id=$series->getId()|escape}" alt="{$series->getLocalizedFullTitle()|escape}" /></a>
 			</div>
 
-			<div class="metadata">				
-			<h3><a href="{url router=$smarty.const.ROUTE_PAGE page="catalog" op="series" path=$browseSeriesItem->getPath()|escape}"> {$browseSeriesItem->getLocalizedFullTitle()|escape}</a></h3>
-		
-			<div class="description">{$browseSeriesItem->getLocalizedDescription()|strip_unsafe_html|truncate:800}</div>
+			<div class="metadata">
+			<h3><a href="{url router=$smarty.const.ROUTE_PAGE page="catalog" op="series" path=$series->getPath()|escape}"> {$series->getLocalizedFullTitle()|escape}</a></h3>
 
-			{if $browseSeriesItem->getPrintISSN()}
-			<div class="printISSN">{translate key="catalog.manage.series.printIssn"} {$browseSeriesItem->getPrintISSN()|escape}</div>{/if}
+			<div class="description">{$series->getLocalizedDescription()|strip_unsafe_html|truncate:800}</div>
 
-			{if $browseSeriesItem->getOnlineISSN()}
-			<div class="onlineISSN">{translate key="catalog.manage.series.onlineIssn"} {$browseSeriesItem->getOnlineISSN()|escape}</div>{/if}
-		
-			</div>								
-			
+			{if $series->getPrintISSN()}
+			<div class="printISSN">{translate key="catalog.manage.series.printIssn"} {$series->getPrintISSN()|escape}</div>{/if}
+
+			{if $series->getOnlineISSN()}
+			<div class="onlineISSN">{translate key="catalog.manage.series.onlineIssn"} {$series->getOnlineISSN()|escape}</div>{/if}
+
+			</div>
+
 		</li>
-		{/iterate}
+		{/foreach}
 
 		{/if}
 	</ul>


### PR DESCRIPTION
This commit makes some changes so that the series index can be found at `/catalog/series`. I'll describe more in the review for this issue: https://github.com/pkp/pkp-lib/issues/6086